### PR TITLE
Report Diagnostic Counters as Delta Counters

### DIFF
--- a/src/Wavefront.OpenTracing.SDK.CSharp/Reporting/WavefrontSpanReporter.cs
+++ b/src/Wavefront.OpenTracing.SDK.CSharp/Reporting/WavefrontSpanReporter.cs
@@ -23,9 +23,9 @@ namespace Wavefront.OpenTracing.SDK.CSharp.Reporting
         private readonly bool reportSpanLogs;
 
         private WavefrontSdkMetricsRegistry sdkMetricsRegistry;
-        private WavefrontSdkCounter spansDropped;
-        private WavefrontSdkCounter spansReceived;
-        private WavefrontSdkCounter reportErrors;
+        private WavefrontSdkDeltaCounter spansDropped;
+        private WavefrontSdkDeltaCounter spansReceived;
+        private WavefrontSdkDeltaCounter reportErrors;
 
         /// <summary>
         ///     Gets the Wavefront proxy or direct ingestion sender.
@@ -234,9 +234,9 @@ namespace Wavefront.OpenTracing.SDK.CSharp.Reporting
             this.sdkMetricsRegistry.Gauge("reporter.queue.size", () => spanBuffer.Count);
             this.sdkMetricsRegistry.Gauge("reporter.queue.remaining_capacity",
                 () => spanBuffer.BoundedCapacity - spanBuffer.Count);
-            spansReceived = this.sdkMetricsRegistry.Counter("reporter.spans.received");
-            spansDropped = this.sdkMetricsRegistry.Counter("reporter.spans.dropped");
-            reportErrors = this.sdkMetricsRegistry.Counter("reporter.errors");
+            spansReceived = this.sdkMetricsRegistry.DeltaCounter("reporter.spans.received");
+            spansDropped = this.sdkMetricsRegistry.DeltaCounter("reporter.spans.dropped");
+            reportErrors = this.sdkMetricsRegistry.DeltaCounter("reporter.errors");
         }
 
         private bool LoggingAllowed()

--- a/src/Wavefront.OpenTracing.SDK.CSharp/Wavefront.OpenTracing.SDK.CSharp.csproj
+++ b/src/Wavefront.OpenTracing.SDK.CSharp/Wavefront.OpenTracing.SDK.CSharp.csproj
@@ -30,9 +30,9 @@
   <ItemGroup>
     <PackageReference Include="OpenTracing" Version="0.12.0" />
     <PackageReference Include="System.Collections.Immutable" Version="1.5.0" />
-    <PackageReference Include="Wavefront.AppMetrics.SDK.CSharp" Version="2.4.0" />
+    <PackageReference Include="Wavefront.AppMetrics.SDK.CSharp" Version="3.1.0" />
     <!-- Remove this once AppMetrics SDK version has been updated. -->
-    <PackageReference Include="Wavefront.SDK.CSharp" Version="1.6.0" />
+    <PackageReference Include="Wavefront.SDK.CSharp" Version="1.7.0" />
   </ItemGroup>
   <ItemGroup>
     <None Include="..\..\LICENSE" Pack="true" PackagePath="" />

--- a/src/Wavefront.OpenTracing.SDK.CSharp/Wavefront.OpenTracing.SDK.CSharp.csproj
+++ b/src/Wavefront.OpenTracing.SDK.CSharp/Wavefront.OpenTracing.SDK.CSharp.csproj
@@ -31,8 +31,6 @@
     <PackageReference Include="OpenTracing" Version="0.12.0" />
     <PackageReference Include="System.Collections.Immutable" Version="1.5.0" />
     <PackageReference Include="Wavefront.AppMetrics.SDK.CSharp" Version="3.1.0" />
-    <!-- Remove this once AppMetrics SDK version has been updated. -->
-    <PackageReference Include="Wavefront.SDK.CSharp" Version="1.7.0" />
   </ItemGroup>
   <ItemGroup>
     <None Include="..\..\LICENSE" Pack="true" PackagePath="" />

--- a/src/Wavefront.OpenTracing.SDK.CSharp/WavefrontSpan.cs
+++ b/src/Wavefront.OpenTracing.SDK.CSharp/WavefrontSpan.cs
@@ -22,7 +22,7 @@ namespace Wavefront.OpenTracing.SDK.CSharp
         private readonly IList<Reference> follows;
         private readonly IList<SpanLog> spanLogs;
 
-        private readonly WavefrontSdkCounter spansDiscarded;
+        private readonly WavefrontSdkDeltaCounter spansDiscarded;
 
         private IList<KeyValuePair<string, string>> tags;
         private IDictionary<string, KeyValuePair<string, string>> singleValuedTags;
@@ -83,7 +83,7 @@ namespace Wavefront.OpenTracing.SDK.CSharp
                 }
             }
 
-            spansDiscarded = tracer.SdkMetricsRegistry?.Counter("spans.discarded");
+            spansDiscarded = tracer.SdkMetricsRegistry?.DeltaCounter("spans.discarded");
         }
 
         /// <inheritdoc />


### PR DESCRIPTION
* Report internal diagnostic metrics as delta counters
* Updated `wavefront-appmetrics-sdk-csharp` version to 3.1.0
* Update `wavefront-sdk-csharp` version to 1.7.0